### PR TITLE
Cleanup Makefile and add install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 CC=c99
-CFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE
+CFLAGS=-O3 -D_FILE_OFFSET_BITS=64 -D_GNU_SOURCE `pkg-config --cflags libelf`
+LDFLAGS=`pkg-config --libs libelf`
 
-LD=ld
-LDFLAGS=
+PREFIX?=/usr/local
+
+MANDIR?=share/man
+BINMODE?=0755
+MANMODE?=644
 
 RM=rm -rf
 
@@ -11,9 +15,13 @@ RM=rm -rf
 
 all: elfcat
 clean:
-	$(RM) elfcat.o elfcat
+	$(RM) elfcat
 
-elfcat.o: elfcat.c
-	$(CC) -c $(CFLAGS) -o elfcat.o elfcat.c
-elfcat: elfcat.o
-	$(CC) $(CFLAGS) -lelf -o elfcat elfcat.o
+elfcat: elfcat.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o elfcat elfcat.c
+
+install: elfcat elfcat.1
+	install -d $(DESTDIR)$(PREFIX)/bin
+	install -m $(BINMODE) elfcat $(DESTDIR)$(PREFIX)/bin
+	install -d $(DESTDIR)$(PREFIX)/$(MANDIR)/man1
+	install -m $(MANMODE) elfcat.1 $(DESTDIR)$(PREFIX)/$(MANDIR)/man1


### PR DESCRIPTION
There is new dependency on pkg-config. It's the sanest way to resolve the dependencies.

```
$ pkg-config --libs libelf
-L/usr/pkg/lib -Wl,-R/usr/pkg/lib -lelf
$ pkg-config --cflags libelf
-I/usr/pkg/include/libelf -I/usr/pkg/include
```
