### PR TITLE
man, fix a typo.

### DIFF
--- a/elfcat.1
+++ b/elfcat.1
@@ -22,7 +22,7 @@ Dumping sections can be achieved with
 .Qq objcopy --dump-section
 but this tools relies on BFD which abstracts
 all executable files and is not able to see some ELF sections.
-Morever it cannot handle program header table entries.
+Moreover, it cannot handle program header table entries.
 .Pp
 Supported options are:
 .Bl -tag -width "--section-index index" -compact


### PR DESCRIPTION
Corrects a typo spotted in pkgsrc-wip package description.
